### PR TITLE
Replace whatsie link to forked repository (MerkeX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 - [Skype](https://www.skype.com/en/) - Skype keeps the world talking, for free. ![Freeware][Freeware Icon]
 - [Telegram](https://desktop.telegram.org/) - A messaging app with a focus on speed and security, it’s super fast, simple and free. [![Open-Source Software][OSS Icon]](https://github.com/overtake/telegram) ![Freeware][Freeware Icon]
 - [Viber](https://www.viber.com/en/products/linux) -Viber for Linux lets you send free messages and make free calls to other Viber users on any device and network, in any country ![Freeware][Freeware Icon]
-- [Whatsie](https://github.com/Aluxian/Whatsie) - Whatsapp unofficial client for ubuntu/linux. [![Open-Source Software][OSS Icon]](https://github.com/Aluxian/Whatsie) ![Freeware][Freeware Icon]
+- [Whatsie](https://github.com/MerkeX/whatsie) - Whatsapp unofficial client for ubuntu/linux. [![Open-Source Software][OSS Icon]](https://github.com/MerkeX/whatsie) ![Freeware][Freeware Icon]
 
 
 ### Data Recovery


### PR DESCRIPTION
## What?
Replace whatsie link to forked repository (MerkeX).

## Why?
`Aluxian/Whatsie` repository has been removed and it looks only `MerkeX/whatsie` is contributing to `whatsie`.